### PR TITLE
Added update preapproval payment

### DIFF
--- a/lib/mercadopago/checkout.rb
+++ b/lib/mercadopago/checkout.rb
@@ -33,7 +33,6 @@ module MercadoPago
     # - preference_id: the payment preference ID
     #
     def self.get_preference(access_token, preference_id)
-      headers = { accept: 'application/json' }
       MercadoPago::Request.wrap_get("/checkout/preferences/#{preference_id}?access_token=#{access_token}")
     end
 
@@ -56,8 +55,20 @@ module MercadoPago
     # - preapproval_id: the preapproval payment ID
     #
     def self.get_preapproval_payment(access_token, preapproval_id)
-      headers = { accept: 'application/json' }
       MercadoPago::Request.wrap_get("/preapproval/#{preapproval_id}?access_token=#{access_token}")
+    end
+
+    #
+    # - access_token: the MercadoPago account associated with this access_token will
+    #                 receive the money from the payment of preapproval payment.
+    # - preapproval_id: the preapproval payment ID
+    # - data: a hash of preferences that will be trasmitted to checkout API.
+    #
+    def self.update_preapproval_payment(access_token, preapproval_id, data)
+      payload = JSON.generate(data)
+      headers = { content_type: 'application/json', accept: 'application/json' }
+
+      MercadoPago::Request.wrap_put("/preapproval/#{preapproval_id}?access_token=#{access_token}", payload, headers)
     end
 
   end

--- a/lib/mercadopago/request.rb
+++ b/lib/mercadopago/request.rb
@@ -26,6 +26,18 @@ module MercadoPago
     end
 
     #
+    # Makes a PUT request to a MercadoPago API.
+    #
+    # - path: the path of the API to be called.
+    # - payload: the data to be trasmitted to the API.
+    # - headers: the headers to be transmitted over the HTTP request.
+    #
+    def self.wrap_put(path, payload, headers = {})
+      raise ClientError('No data given') if payload.nil? or payload.empty?
+      make_request(:put, path, payload, headers)
+    end
+
+    #
     # Makes a GET request to a MercadoPago API.
     #
     # - path: the path of the API to be called, including any query string parameters.


### PR DESCRIPTION
Added the possibility to update a preapproval payment. 

### Example
_Update preapproval payment amount:_

`MercadoPago::Checkout.update_preapproval_payment(ACCESS_TOKEN, PREAPPROVAL_ID, { "auto_recurring" => { "transaction_amount" => 13 } } )`