### PR TITLE
Added Client ability to perform custom GET and POST

### DIFF
--- a/lib/mercadopago/checkout.rb
+++ b/lib/mercadopago/checkout.rb
@@ -1,13 +1,6 @@
-require 'json'
-
 module MercadoPago
 
   module Checkout
-
-    CONTENT_HEADERS = {
-      content_type: 'application/json',
-      accept: 'application/json'
-    }.freeze
 
     #
     # Allows you to configure the checkout process.
@@ -24,8 +17,7 @@ module MercadoPago
 
       MercadoPago::Request
         .wrap_post("/checkout/preferences?access_token=#{access_token}",
-                   payload,
-                   CONTENT_HEADERS)
+                   payload)
     end
 
     #
@@ -55,8 +47,7 @@ module MercadoPago
 
       MercadoPago::Request
         .wrap_post("/preapproval?access_token=#{access_token}",
-                   payload,
-                   CONTENT_HEADERS)
+                   payload)
     end
 
     #

--- a/lib/mercadopago/checkout.rb
+++ b/lib/mercadopago/checkout.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module MercadoPago
 
   module Checkout

--- a/lib/mercadopago/client.rb
+++ b/lib/mercadopago/client.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'json'
+require 'uri'
 
 module MercadoPago
 
@@ -146,26 +147,25 @@ module MercadoPago
     #
     # Performs a generic GET to the given URL
     #
-    # - access_token: the MercadoPago account access token
     # - url: the URL to request
     #
-    def get(url)
-      MercadoPago::Request.wrap_get("#{url}?access_token=#{access_token}")
+    def get(url, data = {}, headers = nil)
+      data[:access_token] = @access_token
+      query = URI.encode_www_form data
+
+      MercadoPago::Request.wrap_get("#{url}?{query}", headers)
     end
 
     #
     # Performs a generic POST to the given URL
     #
-    # - access_token: the MercadoPago account access token
     # - url: the URL to request
     # - data: the data to send along the request
     #
-    def post(url, data)
+    def post(url, data, headers = nil)
       payload = JSON.generate(data)
 
-      MercadoPago::Request
-        .wrap_post("#{url}?access_token=#{access_token}",
-                  payload)
+      MercadoPago::Request.wrap_post("#{url}?access_token=#{@access_token}", payload, headers)
     end
 
     #

--- a/lib/mercadopago/client.rb
+++ b/lib/mercadopago/client.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require 'json'
+
 module MercadoPago
 
   class AccessError < Exception
@@ -139,6 +141,31 @@ module MercadoPago
     #
     def search(search_hash)
       MercadoPago::Collection.search(@access_token, search_hash, @sandbox)
+    end
+
+    #
+    # Performs a generic GET to the given URL
+    #
+    # - access_token: the MercadoPago account access token
+    # - url: the URL to request
+    #
+    def get(url)
+      MercadoPago::Request.wrap_get("#{url}?access_token=#{access_token}")
+    end
+
+    #
+    # Performs a generic POST to the given URL
+    #
+    # - access_token: the MercadoPago account access token
+    # - url: the URL to request
+    # - data: the data to send along the request
+    #
+    def post(url, data)
+      payload = JSON.generate(data)
+
+      MercadoPago::Request
+        .wrap_post("#{url}?access_token=#{access_token}",
+                  payload)
     end
 
     #

--- a/lib/mercadopago/request.rb
+++ b/lib/mercadopago/request.rb
@@ -25,8 +25,9 @@ module MercadoPago
     # - payload: the data to be trasmitted to the API.
     # - headers: the headers to be transmitted over the HTTP request.
     #
-    def self.wrap_post(path, payload, headers = CONTENT_HEADERS)
+    def self.wrap_post(path, payload, headers = nil)
       raise ClientError('No data given') if payload.nil? or payload.empty?
+      headers ||= CONTENT_HEADERS
       make_request(:post, path, payload, headers)
     end
 
@@ -36,7 +37,8 @@ module MercadoPago
     # - path: the path of the API to be called, including any query string parameters.
     # - headers: the headers to be transmitted over the HTTP request.
     #
-    def self.wrap_get(path, headers = {})
+    def self.wrap_get(path, headers = nil)
+      headers ||= CONTENT_HEADERS
       make_request(:get, path, nil, headers)
     end
 

--- a/lib/mercadopago/request.rb
+++ b/lib/mercadopago/request.rb
@@ -8,6 +8,11 @@ module MercadoPago
     class ClientError < Exception
     end
 
+    CONTENT_HEADERS = {
+      content_type: 'application/json',
+      accept: 'application/json'
+    }.freeze
+
     #
     # This URL is the base for all API calls.
     #
@@ -20,7 +25,7 @@ module MercadoPago
     # - payload: the data to be trasmitted to the API.
     # - headers: the headers to be transmitted over the HTTP request.
     #
-    def self.wrap_post(path, payload, headers = {})
+    def self.wrap_post(path, payload, headers = CONTENT_HEADERS)
       raise ClientError('No data given') if payload.nil? or payload.empty?
       make_request(:post, path, payload, headers)
     end


### PR DESCRIPTION
The official MercadoPago ruby SDK [supports generic methods](https://github.com/mercadopago/sdk-ruby#generic-methods) in order to access any other resource not available as a method.

I've seen this feature useful because I needed to create a preapproval plan as a POST to `/preapproval_plan`. Though I could simply add a function to do it, I took the chance to implement generic calls at once.