### PR TITLE
Fix #37: Don't require refresh_token definitively

### DIFF
--- a/lib/mercadopago/client.rb
+++ b/lib/mercadopago/client.rb
@@ -193,7 +193,7 @@ module MercadoPago
 
       if (auth.keys & mandatory_keys) == mandatory_keys
         @access_token   = auth['access_token']
-        @refresh_token  = auth['refresh_token'] # Sometimes refresh_token is not received
+        @refresh_token  = auth['refresh_token']
       else
         raise AccessError, auth['message']
       end


### PR DESCRIPTION
Mercadolibre answered me about the `refresh_token` issue, it was in fact a bug from their API and they fixed it now, however, I think we should still don't require it to determine if we could authenticate or no, because `refresh_token` is needed only if we want to use it and if it doesn't come again, only the refresh call will fail as it will be `nil`, but the first-time authentication will not depend on that.