### PR TITLE
Use TLS v1.2 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ You can read the documentation of the MercadoPago API here:
 Installation
 ------------
 
-mercadopago 2.3.0 needs Ruby >= 2.0.0. For Ruby 1.9 support, use mercadopago ~> 2.2.0.
+mercadopago 2.3.0 needs Ruby >= 2.0.0. Ruby 1.9.3 does not support TLS v1.2,
+which is required by MercadoPago starting June 30th 2018.
 
 To install the last version of the gem:
 

--- a/lib/mercadopago/request.rb
+++ b/lib/mercadopago/request.rb
@@ -65,7 +65,7 @@ module MercadoPago
     def self.make_request(type, path, payload = nil, headers = {})
       args = [type, MERCADOPAGO_URL, path, payload, headers].compact
 
-      connection = Faraday.new(MERCADOPAGO_URL)
+      connection = Faraday.new(MERCADOPAGO_URL, ssl: { version: :TLSv1_2 })
 
       response = connection.send(type) do |req|
         req.url path


### PR DESCRIPTION
Hey, 

Starting June 30th 2018, MercadoPago drops TLS v1.0 support: http://beta.mercadopago.com.ar/developers/es/guides/pci-compliant-merchants/disabling-tls-10

This means only TLS v1.1 and TLS v1.2 will be supported by the API, and Ruby 1.9.3 will not be supported since TLS v1.1 and TLS v1.2 support was introduced in Ruby 2.0.0.  

I'm forcing a TLS v1.2 connection because Faraday requires at least Ruby 2.5 to be able to set a min/max SSL version. 

Please check it out and let me know what you think, thanks! 