### PR TITLE
Allow faraday to be updated to 0.17.3

### DIFF
--- a/mercadopago.gemspec
+++ b/mercadopago.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here:
   s.add_dependency 'json', '~> 1.4'
-  s.add_dependency 'faraday', '~> 0.9.0'
+  s.add_dependency 'faraday', '~> 0.9'
   s.add_development_dependency 'pry', '~> 0.11.1'
   s.add_development_dependency 'rake', '~> 12.1'
   s.add_development_dependency 'byebug', '~> 9.1'


### PR DESCRIPTION
Faraday 0.17.3 contains some fixes for ruby 2.7.

See https://github.com/lostisland/faraday/blob/master/CHANGELOG.md