### PR TITLE
Bump json gem version

### DIFF
--- a/mercadopago.gemspec
+++ b/mercadopago.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here:
-  s.add_dependency 'json', '~> 1.4'
+  s.add_dependency 'json', '~> 2.3'
   s.add_dependency 'faraday', '~> 0.9'
   s.add_development_dependency 'pry', '~> 0.11.1'
   s.add_development_dependency 'rake', '~> 12.1'


### PR DESCRIPTION
Json <= 2.2 had a Critical security Issue.
See: https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/

Issue https://github.com/ombulabs/mercadopago/issues/46